### PR TITLE
Fix key for hmac signature

### DIFF
--- a/src/hmacvalidator/hmacvalidator.go
+++ b/src/hmacvalidator/hmacvalidator.go
@@ -31,7 +31,7 @@ func ValidateHmac(notificationRequestItem notification.NotificationRequestItem, 
 	if err != nil {
 		return false
 	}
-	merchantSign := (*notificationRequestItem.AdditionalData)["HmacSignature"]
+	merchantSign := (*notificationRequestItem.AdditionalData)["hmacSignature"]
 	return expectedSign == merchantSign
 }
 

--- a/src/hmacvalidator/hmacvalidator_test.go
+++ b/src/hmacvalidator/hmacvalidator_test.go
@@ -13,7 +13,7 @@ const expectedSign = "ipnxGCaUZ4l8TUW75a71/ghd2Fe5ffvX0pV4TLTntIc="
 
 var eventDate = time.Date(1970, time.January, 01, 0, 0, 0, 0, time.UTC)
 var notificationRequestItem = notification.NotificationRequestItem{
-	AdditionalData: &map[string]interface{}{"HmacSignature": expectedSign},
+	AdditionalData: &map[string]interface{}{"hmacSignature": expectedSign},
 	Amount: notification.Amount{
 		Currency: "EUR",
 		Value:    1000,
@@ -64,7 +64,7 @@ func Test_Hmacvalidator(t *testing.T) {
 			assert.True(t, ValidateHmac(notificationRequestItem, key))
 		})
 		t.Run("Get Invalid HMAC", func(t *testing.T) {
-			notificationRequestItem.AdditionalData = &map[string]interface{}{"HmacSignature": "InvalidSignature"}
+			notificationRequestItem.AdditionalData = &map[string]interface{}{"hmacSignature": "InvalidSignature"}
 			assert.False(t, ValidateHmac(notificationRequestItem, key))
 		})
 	})


### PR DESCRIPTION
Key had wrong capitalization:
https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures#enable-hmac-signatures