### PR TITLE
Fix/issue 83 idempotency key

### DIFF
--- a/src/adyen/api.go
+++ b/src/adyen/api.go
@@ -252,13 +252,3 @@ func (c *APIClient) SetEnvironment(env common.Environment, liveEndpointURLPrefix
 func (c *APIClient) GetConfig() *common.Config {
 	return c.client.Cfg
 }
-
-/*
-SetIdempotencyKey A idempotency key is added to the request headers once. A subsequent request using the same
-idempotency key will be processed as if it was the first request.
-This header option is not persistent which means that whenever you want to use a idempotency key, you need to
-"SetIdempotencyKey" again before each request.
-*/
-func (c *APIClient) SetIdempotencyKey(i string) {
-	c.client.Cfg.AddDefaultHeader("Idempotency-Key", i)
-}

--- a/src/common/client.go
+++ b/src/common/client.go
@@ -88,11 +88,6 @@ func (c *Client) MakeHTTPPostRequest(req interface{}, res interface{}, path stri
 
 	httpResponse, err := c.CallAPI(r)
 
-	_, ok := c.Cfg.DefaultHeader["Idempotency-Key"]
-	if ok {
-		delete(c.Cfg.DefaultHeader, "Idempotency-Key")
-	}
-
 	if err != nil || httpResponse == nil {
 		return httpResponse, err
 	}
@@ -245,6 +240,10 @@ func (c *Client) PrepareRequest(
 
 	for header, value := range c.Cfg.DefaultHeader {
 		localVarRequest.Header.Add(header, value)
+	}
+
+	if key, ok := IdempotencyKey(ctx); ok {
+		localVarRequest.Header.Add("Idempotency-Key", key)
 	}
 
 	return localVarRequest, nil
@@ -530,4 +529,26 @@ func (e APIError) Error() string {
 		return fmt.Sprintf("%s: %s (%s: %s)", e.Err, e.Message, e.Type, e.Code)
 	}
 	return e.Err
+}
+
+type ctxKey int
+
+var ctxKeyIdempotencyKey ctxKey = 1
+
+/*
+WithIdempotencyKey returns a context with an Idempotency-Key added to the provided context.
+Pass this context as the first context to a call to Adyen, and the idempotency
+key will be added to the header
+*/
+func WithIdempotencyKey(ctx context.Context, i string) context.Context {
+	return context.WithValue(ctx, ctxKeyIdempotencyKey, i)
+}
+
+func IdempotencyKey(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	ikey := ctx.Value(ctxKeyIdempotencyKey)
+	key, ok := ikey.(string)
+	return key, ok
 }

--- a/src/common/configuration.go
+++ b/src/common/configuration.go
@@ -98,8 +98,3 @@ func (c *Config) GetCheckoutEndpoint() (string, error) {
 	}
 	return c.CheckoutEndpoint, nil
 }
-
-// AddDefaultHeader adds a new HTTP header to the default header in the Request
-func (c *Config) AddDefaultHeader(key string, value string) {
-	c.DefaultHeader[key] = value
-}

--- a/tests/checkout_test.go
+++ b/tests/checkout_test.go
@@ -7,10 +7,12 @@
 package tests
 
 import (
-	"github.com/google/uuid"
+	"context"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/adyen/adyen-go-api-library/v2/src/adyen"
 	"github.com/adyen/adyen-go-api-library/v2/src/checkout"
@@ -184,12 +186,13 @@ func Test_Checkout(t *testing.T) {
 			require.Nil(t, req.ApplicationInfo)
 
 			iKey := uuid.New().String()
-			client.SetIdempotencyKey(iKey)
-			res, _, _ := client.Checkout.Payments(req)
+			ctx := context.Background()
+			ctx = common.WithIdempotencyKey(ctx, iKey)
+			res, _, _ := client.Checkout.Payments(req, ctx)
 			pspRef := res.PspReference
 
-			client.SetIdempotencyKey(iKey)
-			res, _, _ = client.Checkout.Payments(req)
+			ctx = common.WithIdempotencyKey(ctx, iKey)
+			res, _, _ = client.Checkout.Payments(req, ctx)
 			require.Equal(t, pspRef, res.PspReference)
 
 			// Idempotency Key is not set for this request. Should have a new PspReference.

--- a/tests/checkoutidempotency_test.go
+++ b/tests/checkoutidempotency_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/adyen/adyen-go-api-library/v2/src/adyen"
+	"github.com/adyen/adyen-go-api-library/v2/src/checkout"
+	"github.com/adyen/adyen-go-api-library/v2/src/common"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+var idempotencyKeys *sync.Map
+
+type referenceAndIdempotencyKeyTransport struct {
+	errChan chan error
+}
+
+func (rl *referenceAndIdempotencyKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _ := ioutil.ReadAll(req.Body)
+	data := map[string]interface{}{}
+	json.Unmarshal(body, &data)
+	reference := data["reference"]
+	idempotencyKey := req.Header.Get("Idempotency-Key")
+	idempotencyKeys.Store(reference.(string), idempotencyKey)
+	resp := httptest.NewRecorder()
+	resp.WriteHeader(http.StatusOK)
+	return resp.Result(), nil
+}
+
+func Test_Checkout_Idempotency_Race(t *testing.T) {
+	idempotencyKeys = &sync.Map{}
+	client := adyen.NewClient(&common.Config{
+		HTTPClient: &http.Client{
+			Transport: &referenceAndIdempotencyKeyTransport{},
+		},
+	})
+
+	for r := 0; r < 10; r++ {
+		t.Run(fmt.Sprintf("Routine %d", r), func(t *testing.T) {
+			ir := r
+			t.Parallel()
+			for i := 0; i < 100; i++ {
+				idempotencyKey := uuid.Must(uuid.NewRandom()).String()
+				ref := fmt.Sprintf("%d/%d", ir, i)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancel()
+				ctx = common.WithIdempotencyKey(ctx, idempotencyKey)
+				_, _, err := client.Checkout.Payments(&checkout.PaymentRequest{
+					Reference: ref,
+				}, ctx)
+				require.NoError(t, err)
+				v, ok := idempotencyKeys.Load(ref)
+				require.True(t, ok)
+				require.Equal(t, v.(string), idempotencyKey)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes the problem with using idempotency keys in multiple goroutines.
The solution puts the idempotency key into the context. That is one way of doing it.
## Tested scenarios
Added a test that starts 10 parallel tests that each send 100 requests to a fake Transporter. The received idempotency-key is then compared with the sent one.

**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes https://github.com/Adyen/adyen-go-api-library/issues/83
