### PR TITLE
Update model_payment_request.go

### DIFF
--- a/src/checkout/model_payment_request.go
+++ b/src/checkout/model_payment_request.go
@@ -110,7 +110,7 @@ type PaymentRequest struct {
 	// The physical store, for which this payment is processed.
 	Store string `json:"store,omitempty"`
 	// When true and `shopperReference` is provided, the payment details will be stored.
-	StorePaymentMethod bool `json:"storePaymentMethod,omitempty"`
+	StorePaymentMethod *bool `json:"storePaymentMethod,omitempty"`
 	// The shopper's telephone number.
 	TelephoneNumber     string               `json:"telephoneNumber,omitempty"`
 	ThreeDS2RequestData *ThreeDS2RequestData `json:"threeDS2RequestData,omitempty"`


### PR DESCRIPTION
First of all we are using Adyen Go API Library in our project. We have a function that returns this request model as stated below:
https://github.com/Adyen/adyen-go-api-library/blob/develop/src/checkout/model_payment_request.go
We want to make storing payment methods optional. When we try to pass false value into this struct it omits by default that's why it always saves the card.

The problem is the definition of StorePaymentMethod in PaymentRequest struct, line 113.
StorePaymentMethod bool `json:"storePaymentMethod,omitempty"`

For example, we are trying to return a PaymentRequest struct as we shared in attached image 1. When we send a request to this endpoint with these parameters it saves the card anyways.

<img width="674" alt="image1" src="https://user-images.githubusercontent.com/95672179/162892772-182564bc-8d02-4a7f-8d78-43e0e7d92a6f.png">

Our solution is changing the definition of StorePaymentMethod in PaymentRequest struct as we state below:
StorePaymentMethod *bool `json:"storePaymentMethod,omitempty"`

Using pointer in struct fields provides us sending false value in StorePaymentMethod as PaymentRequest and we will use it as we shared in attached image 2.

<img width="690" alt="image2" src="https://user-images.githubusercontent.com/95672179/162892791-187e3e96-948c-43ab-92ff-61cfa4de7127.png">

If Adyen developers can update this repository as we requested, our problem will be resolved.

