### PR TITLE
Remove omitempty to retain default value (false)

### DIFF
--- a/src/checkout/model_payment_request.go
+++ b/src/checkout/model_payment_request.go
@@ -9,34 +9,36 @@
  */
 
 package checkout
+
 import (
 	"time"
 )
+
 // PaymentRequest struct for PaymentRequest
 type PaymentRequest struct {
 	AccountInfo *AccountInfo `json:"accountInfo,omitempty"`
 	// This field contains additional data, which may be required for a particular payment request.  The `additionalData` object consists of entries, each of which includes the key and value.
-	AdditionalData map[string]string `json:"additionalData,omitempty"`
-	Amount Amount `json:"amount"`
-	ApplicationInfo *ApplicationInfo `json:"applicationInfo,omitempty"`
+	AdditionalData     map[string]string   `json:"additionalData,omitempty"`
+	Amount             Amount              `json:"amount"`
+	ApplicationInfo    *ApplicationInfo    `json:"applicationInfo,omitempty"`
 	AuthenticationData *AuthenticationData `json:"authenticationData,omitempty"`
-	BillingAddress *Address `json:"billingAddress,omitempty"`
-	BrowserInfo *BrowserInfo `json:"browserInfo,omitempty"`
+	BillingAddress     *Address            `json:"billingAddress,omitempty"`
+	BrowserInfo        *BrowserInfo        `json:"browserInfo,omitempty"`
 	// The delay between the authorisation and scheduled auto-capture, specified in hours.
 	CaptureDelayHours int32 `json:"captureDelayHours,omitempty"`
 	// The platform where a payment transaction takes place. This field is optional for filtering out payment methods that are only available on specific platforms. If this value is not set, then we will try to infer it from the `sdkVersion` or `token`.  Possible values: * iOS * Android * Web
 	Channel string `json:"channel,omitempty"`
 	// Checkout attempt ID that corresponds to the Id generated for tracking user payment journey.
-	CheckoutAttemptId string `json:"checkoutAttemptId,omitempty"`
-	Company *Company `json:"company,omitempty"`
+	CheckoutAttemptId string   `json:"checkoutAttemptId,omitempty"`
+	Company           *Company `json:"company,omitempty"`
 	// Conversion ID that corresponds to the Id generated for tracking user payment journey.
 	ConversionId string `json:"conversionId,omitempty"`
 	// The shopper country.  Format: [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) Example: NL or DE
 	CountryCode string `json:"countryCode,omitempty"`
 	// The shopper's date of birth.  Format [ISO-8601](https://www.w3.org/TR/NOTE-datetime): YYYY-MM-DD
-	DateOfBirth *time.Time `json:"dateOfBirth,omitempty"`
-	DccQuote *ForexQuote `json:"dccQuote,omitempty"`
-	DeliveryAddress *Address `json:"deliveryAddress,omitempty"`
+	DateOfBirth     *time.Time  `json:"dateOfBirth,omitempty"`
+	DccQuote        *ForexQuote `json:"dccQuote,omitempty"`
+	DeliveryAddress *Address    `json:"deliveryAddress,omitempty"`
 	// The date and time the purchased goods should be delivered.  Format [ISO 8601](https://www.w3.org/TR/NOTE-datetime): YYYY-MM-DDThh:mm:ss.sssTZD  Example: 2017-07-17T13:42:40.428+01:00
 	DeliveryDate *time.Time `json:"deliveryDate,omitempty"`
 	// A string containing the shopper's device fingerprint. For more information, refer to [Device fingerprinting](https://docs.adyen.com/risk-management/device-fingerprinting).
@@ -50,22 +52,22 @@ type PaymentRequest struct {
 	// The type of the entity the payment is processed for.
 	EntityType string `json:"entityType,omitempty"`
 	// An integer value that is added to the normal fraud score. The value can be either positive or negative.
-	FraudOffset int32 `json:"fraudOffset,omitempty"`
+	FraudOffset  int32         `json:"fraudOffset,omitempty"`
 	Installments *Installments `json:"installments,omitempty"`
 	// Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, Zip and Atome.
 	LineItems *[]LineItem `json:"lineItems,omitempty"`
-	Mandate *Mandate `json:"mandate,omitempty"`
+	Mandate   *Mandate    `json:"mandate,omitempty"`
 	// The [merchant category code](https://en.wikipedia.org/wiki/Merchant_category_code) (MCC) is a four-digit number, which relates to a particular market segment. This code reflects the predominant activity that is conducted by the merchant.
 	Mcc string `json:"mcc,omitempty"`
 	// The merchant account identifier, with which you want to process the transaction.
 	MerchantAccount string `json:"merchantAccount"`
 	// This reference allows linking multiple transactions to each other for reporting purposes (i.e. order auth-rate). The reference should be unique per billing cycle. The same merchant order reference should never be reused after the first authorised attempt. If used, this field should be supplied for all incoming authorisations. > We strongly recommend you send the `merchantOrderReference` value to benefit from linking payment requests when authorisation retries take place. In addition, we recommend you provide `retry.orderAttemptNumber`, `retry.chainAttemptNumber`, and `retry.skipRetry` values in `PaymentRequest.additionalData`.
-	MerchantOrderReference string `json:"merchantOrderReference,omitempty"`
-	MerchantRiskIndicator *MerchantRiskIndicator `json:"merchantRiskIndicator,omitempty"`
-	// Metadata consists of entries, each of which includes a key and a value. Limits: * Maximum 20 key-value pairs per request. When exceeding, the \"177\" error occurs: \"Metadata size exceeds limit\". * Maximum 20 characters per key. * Maximum 80 characters per value. 
+	MerchantOrderReference string                 `json:"merchantOrderReference,omitempty"`
+	MerchantRiskIndicator  *MerchantRiskIndicator `json:"merchantRiskIndicator,omitempty"`
+	// Metadata consists of entries, each of which includes a key and a value. Limits: * Maximum 20 key-value pairs per request. When exceeding, the \"177\" error occurs: \"Metadata size exceeds limit\". * Maximum 20 characters per key. * Maximum 80 characters per value.
 	Metadata map[string]string `json:"metadata,omitempty"`
-	MpiData *ThreeDSecureData `json:"mpiData,omitempty"`
-	Order *CheckoutOrder `json:"order,omitempty"`
+	MpiData  *ThreeDSecureData `json:"mpiData,omitempty"`
+	Order    *CheckoutOrder    `json:"order,omitempty"`
 	// When you are doing multiple partial (gift card) payments, this is the `pspReference` of the first payment. We use this to link the multiple payments to each other. As your own reference for linking multiple payments, use the `merchantOrderReference`instead.
 	OrderReference string `json:"orderReference,omitempty"`
 	// Required for the 3D Secure 2 `channel` **Web** integration.  Set this parameter to the origin URL of the page that you are loading the 3D Secure Component from.
@@ -76,7 +78,7 @@ type PaymentRequest struct {
 	RecurringExpiry string `json:"recurringExpiry,omitempty"`
 	// Minimum number of days between authorisations. Only for 3D Secure 2.
 	RecurringFrequency string `json:"recurringFrequency,omitempty"`
-	// Defines a recurring payment type. Allowed values: * `Subscription` – A transaction for a fixed or variable amount, which follows a fixed schedule. * `CardOnFile` – With a card-on-file (CoF) transaction, card details are stored to enable one-click or omnichannel journeys, or simply to streamline the checkout process. Any subscription not following a fixed schedule is also considered a card-on-file transaction. * `UnscheduledCardOnFile` – An unscheduled card-on-file (UCoF) transaction is a transaction that occurs on a non-fixed schedule and/or have variable amounts. For example, automatic top-ups when a cardholder's balance drops below a certain amount. 
+	// Defines a recurring payment type. Allowed values: * `Subscription` – A transaction for a fixed or variable amount, which follows a fixed schedule. * `CardOnFile` – With a card-on-file (CoF) transaction, card details are stored to enable one-click or omnichannel journeys, or simply to streamline the checkout process. Any subscription not following a fixed schedule is also considered a card-on-file transaction. * `UnscheduledCardOnFile` – An unscheduled card-on-file (UCoF) transaction is a transaction that occurs on a non-fixed schedule and/or have variable amounts. For example, automatic top-ups when a cardholder's balance drops below a certain amount.
 	RecurringProcessingModel string `json:"recurringProcessingModel,omitempty"`
 	// Specifies the redirect method (GET or POST) when redirecting back from the issuer.
 	RedirectFromIssuerMethod string `json:"redirectFromIssuerMethod,omitempty"`
@@ -85,8 +87,8 @@ type PaymentRequest struct {
 	// The reference to uniquely identify a payment. This reference is used in all communication with you about the payment status. We recommend using a unique value per payment; however, it is not a requirement. If you need to provide multiple references for a transaction, separate them with hyphens (\"-\"). Maximum length: 80 characters.
 	Reference string `json:"reference"`
 	// The URL to return to in case of a redirection. The format depends on the channel. This URL can have a maximum of 1024 characters. * For web, include the protocol `http://` or `https://`. You can also include your own additional query parameters, for example, shopper ID or order reference number. Example: `https://your-company.com/checkout?shopperOrder=12xy` * For iOS, use the custom URL for your app. To know more about setting custom URL schemes, refer to the [Apple Developer documentation](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app). Example: `my-app://` * For Android, use a custom URL handled by an Activity on your app. You can configure it with an [intent filter](https://developer.android.com/guide/components/intents-filters). Example: `my-app://your.package.name`
-	ReturnUrl string `json:"returnUrl"`
-	RiskData *RiskData `json:"riskData,omitempty"`
+	ReturnUrl string    `json:"returnUrl"`
+	RiskData  *RiskData `json:"riskData,omitempty"`
 	// The date and time until when the session remains valid, in [ISO 8601](https://www.w3.org/TR/NOTE-datetime) format.  For example: 2020-07-18T15:42:40.428+01:00
 	SessionValidity string `json:"sessionValidity,omitempty"`
 	// The shopper's email address. We recommend that you provide this data, as it is used in velocity fraud checks. > For 3D Secure 2 transactions, schemes require `shopperEmail` for all browser-based and mobile implementations.
@@ -97,7 +99,7 @@ type PaymentRequest struct {
 	ShopperInteraction string `json:"shopperInteraction,omitempty"`
 	// The combination of a language code and a country code to specify the language to be used in the payment.
 	ShopperLocale string `json:"shopperLocale,omitempty"`
-	ShopperName *Name `json:"shopperName,omitempty"`
+	ShopperName   *Name  `json:"shopperName,omitempty"`
 	// Required for recurring payments.  Your reference to uniquely identify this shopper, for example user ID or account ID. Minimum length: 3 characters. > Your reference must not include personally identifiable information (PII), for example name or email address.
 	ShopperReference string `json:"shopperReference,omitempty"`
 	// The text to be shown on the shopper's bank statement.  We recommend sending a maximum of 22 characters, otherwise banks might truncate the string.  Allowed characters: **a-z**, **A-Z**, **0-9**, spaces, and special characters **. , ' _ - ? + * /_**.
@@ -109,9 +111,9 @@ type PaymentRequest struct {
 	// The ecommerce or point-of-sale store that is processing the payment. Used in [partner arrangement integrations](https://docs.adyen.com/platforms/platforms-for-partners#route-payments) for Adyen for Platforms.
 	Store string `json:"store,omitempty"`
 	// When true and `shopperReference` is provided, the payment details will be stored.
-	StorePaymentMethod bool `json:"storePaymentMethod,omitempty"`
+	StorePaymentMethod bool `json:"storePaymentMethod"`
 	// The shopper's telephone number.
-	TelephoneNumber string `json:"telephoneNumber,omitempty"`
+	TelephoneNumber     string               `json:"telephoneNumber,omitempty"`
 	ThreeDS2RequestData *ThreeDS2RequestData `json:"threeDS2RequestData,omitempty"`
 	// If set to true, you will only perform the [3D Secure 2 authentication](https://docs.adyen.com/online-payments/3d-secure/other-3ds-flows/authentication-only), and not the payment authorisation.
 	ThreeDSAuthenticationOnly bool `json:"threeDSAuthenticationOnly,omitempty"`

--- a/tests/model_payment_request_test.go
+++ b/tests/model_payment_request_test.go
@@ -87,7 +87,7 @@ func TestPaymentRequest_UnmarshalJSON(t *testing.T) {
 
 				jsonString, err := json.Marshal(got)
 				assert.Nil(t, err)
-				assert.Equal(t, `{"amount":{"currency":"","value":0},"browserInfo":{"acceptHeader":"*/*","colorDepth":24,"javaEnabled":false,"language":"en-US","screenHeight":1080,"screenWidth":1920,"timeZoneOffset":-60,"userAgent":"Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"},"merchantAccount":"","paymentMethod":{"brand":"amex","encryptedCardNumber":"adyenjs_0_1_25$J8/5xp5l6DjYVPokO6FwAQj","encryptedExpiryMonth":"adyenjs_0_1_25$bLCWe/ZHR37Okz0d28bzrDBYXw","encryptedExpiryYear":"adyenjs_0_1_25$nqasksbOSfn0grzrmna2vpWkQMhOHT6Cd","encryptedSecurityCode":"adyenjs_0_1_25$TbomjrfaGwHFfxpPuf","holderName":"d","type":"scheme"},"reference":"","returnUrl":"","riskData":{"clientData":"eyJ2ZXJzaW9uIjoiMS4w"}}`, string(jsonString))
+				assert.Equal(t, `{"amount":{"currency":"","value":0},"browserInfo":{"acceptHeader":"*/*","colorDepth":24,"javaEnabled":false,"language":"en-US","screenHeight":1080,"screenWidth":1920,"timeZoneOffset":-60,"userAgent":"Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"},"merchantAccount":"","paymentMethod":{"brand":"amex","encryptedCardNumber":"adyenjs_0_1_25$J8/5xp5l6DjYVPokO6FwAQj","encryptedExpiryMonth":"adyenjs_0_1_25$bLCWe/ZHR37Okz0d28bzrDBYXw","encryptedExpiryYear":"adyenjs_0_1_25$nqasksbOSfn0grzrmna2vpWkQMhOHT6Cd","encryptedSecurityCode":"adyenjs_0_1_25$TbomjrfaGwHFfxpPuf","holderName":"d","type":"scheme"},"reference":"","returnUrl":"","riskData":{"clientData":"eyJ2ZXJzaW9uIjoiMS4w"},"storePaymentMethod":false}`, string(jsonString))
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestPaymentRequest_UnmarshalJSON(t *testing.T) {
 
 				jsonString, err := json.Marshal(got)
 				assert.Nil(t, err)
-				assert.Equal(t, `{"amount":{"currency":"","value":0},"browserInfo":{"acceptHeader":"*/*","colorDepth":24,"javaEnabled":false,"language":"en-US","screenHeight":1080,"screenWidth":1920,"timeZoneOffset":-60,"userAgent":"Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"},"merchantAccount":"","paymentMethod":{"brand":"amex","holderName":"d","number":"1234","type":"mypay"},"reference":"","returnUrl":"","riskData":{"clientData":"eyJ2ZXJzaW9uIjoiMS4w"}}`, string(jsonString))
+				assert.Equal(t, `{"amount":{"currency":"","value":0},"browserInfo":{"acceptHeader":"*/*","colorDepth":24,"javaEnabled":false,"language":"en-US","screenHeight":1080,"screenWidth":1920,"timeZoneOffset":-60,"userAgent":"Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0"},"merchantAccount":"","paymentMethod":{"brand":"amex","holderName":"d","number":"1234","type":"mypay"},"reference":"","returnUrl":"","riskData":{"clientData":"eyJ2ZXJzaW9uIjoiMS4w"},"storePaymentMethod":false}`, string(jsonString))
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
As raised in #133 the developer is incurring the following problem

> We want to make storing payment methods optional. When we try to pass false value into this struct it omits by default that's why it always saves the card.

This is going to be addressed in the Adyen (backend) platform (when `false` or missing the payment methods shall not be stored), meanwhile we can address this in the Go SDK

## Tested scenarios
Verified the payload sent to the Adyen (backend) platform, it contains now `storePaymentMethod:false`

**Fixed issue**:  
Fix #133 
