### PR TITLE
fix panic when NotificationItems is nil

### DIFF
--- a/src/notification/model_notification.go
+++ b/src/notification/model_notification.go
@@ -8,6 +8,11 @@ type Notification struct {
 // GetNotificationItems returns a reference to NotificationRequestItem's inside the NotificationItem array
 func (n *Notification) GetNotificationItems() []*NotificationRequestItem {
 	resp := []*NotificationRequestItem{}
+
+	if n.NotificationItems == nil {
+		return resp
+	}
+
 	for _, v := range *n.NotificationItems {
 		resp = append(resp, &v.NotificationRequestItem)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When notification webhook receives an empty http body, Notification.GetNotificationItems causes panic
This PR adds check of nil pointer on NotificationItems

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
