### PR TITLE
Delete dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
This PR removes Dependabot configuration (we have already enabled Renovate bot)

## Summary
Delete dependabot config file

## Tested scenarios
N/A

