### PR TITLE
[redo] Fix models workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ templates: $(openapi-generator-jar)
 
 # Download the generator
 $(openapi-generator-jar):
+	mkdir -p bin
 	wget --quiet -o /dev/null $(openapi-generator-url) -O $(openapi-generator-jar)
 
 # Download the import optimizer (and code formatter)


### PR DESCRIPTION
Fixes the following error: 

```
> Run make models
git clone https://github.com/Adyen/adyen-openapi.git schema
Cloning into 'schema'...
perl -i -pe 's/"openapi" : "3.[0-9].[0-9]"/"openapi" : "3.0.0"/' schema/json/*.json
wget --quiet -o /dev/null https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.[4](https://github.com/Adyen/adyen-go-api-library/actions/runs/4676757372/jobs/8283451736#step:3:5).0/openapi-generator-cli-[6](https://github.com/Adyen/adyen-go-api-library/actions/runs/4676757372/jobs/8283451736#step:3:7).4.0.jar -O bin/openapi-generator-cli.jar
bin/openapi-generator-cli.jar: No such file or directory
make: *** [Makefile:64: bin/openapi-generator-cli.jar] Error 1
```

https://github.com/Adyen/adyen-go-api-library/actions/runs/4676757372/jobs/8283451736#step:3:9