### PR TITLE
Do not skip JSON serialization for readOnly fields

### DIFF
--- a/templates/custom/model_simple.mustache
+++ b/templates/custom/model_simple.mustache
@@ -311,7 +311,6 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	{{/isNullable}}
 	{{! if argument is not nullable, don't set it if it is nil}}
 	{{^isNullable}}
-	{{^isReadOnly}}
 	{{#required}}
 	toSerialize["{{baseName}}"] = o.{{name}}
 	{{/required}}
@@ -320,10 +319,6 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 		toSerialize["{{baseName}}"] = o.{{name}}
 	}
 	{{/required}}
-	{{/isReadOnly}}
-	{{#isReadOnly}}
-	// skip: {{baseName}} is readOnly
-	{{/isReadOnly}}
 	{{/isNullable}}
 	{{/vars}}
 	{{#isAdditionalPropertiesTrue}}


### PR DESCRIPTION
## Summary
During the model serialisation the `readOnly` fields are skipped. This is a problem as fields like `id` are skipped and not included in the response body, for example in the `CreateCheckoutSessionResponse` model:

```
func (o CreateCheckoutSessionResponse) ToMap() (map[string]interface{}, error) {
	toSerialize := map[string]interface{}{}
        ...
	if !common.IsNil(o.FundRecipient) {
		toSerialize["fundRecipient"] = o.FundRecipient
	}
	// skip: id is readOnly
	if !common.IsNil(o.InstallmentOptions) {
		toSerialize["installmentOptions"] = o.InstallmentOptions
	}
```


## Tested scenarios
The Go sample app is not able to load the drop-in as the session Id is missing, causing `Error: Invalid session` 

## Solution
The templates have been updated to ensure the serialisation does not skip any field.

