### PR TITLE
Hmac validation bank webhooks

### DIFF
--- a/src/hmacvalidator/hmacvalidator.go
+++ b/src/hmacvalidator/hmacvalidator.go
@@ -25,7 +25,12 @@ func CalculateHmac(data interface{}, secret string) (string, error) {
 	}
 }
 
-// ValidateHmac calculates the HMAC of the notification request item and checks if it matches with the given key
+// ValidateHmac validates the HMAC signature of the NotificationRequestItem object. Use for webhooks that provide the
+// hmacSignature as part of the payload `AdditionalData` (i.e. Payments)
+//
+// Params:
+// notificationRequestItem: NotificationRequestItem object
+// key: HMAC key to generate the signature
 func ValidateHmac(notificationRequestItem webhook.NotificationRequestItem, key string) bool {
 	expectedSign, err := CalculateHmac(notificationRequestItem, key)
 	if err != nil {
@@ -35,7 +40,22 @@ func ValidateHmac(notificationRequestItem webhook.NotificationRequestItem, key s
 	return expectedSign == merchantSign
 }
 
-// GetDataToSign converts a notification request item to string, which later on can be used for calculating a HMAC
+// ValidateHmacPayload validates the HMAC signature of a payload against an expected signature. Use for webhooks that provide the
+// hmacSignature in the HTTP header (i.e. Banking, Management API)
+//
+// Params:
+// hmacSignature: HMAC signature to validate
+// key: HMAC key to generate the signature
+// payload: webhook payload
+func ValidateHmacPayload(hmacSignature string, key string, payload string) bool {
+	expectedSign, err := CalculateHmac(payload, key)
+	if err != nil {
+		return false
+	}
+	return expectedSign == hmacSignature
+}
+
+// GetDataToSign converts a notificationRequestItem to string, which later on can be used for calculating a HMAC
 func GetDataToSign(notificationRequestItem interface{}) string {
 	switch item := notificationRequestItem.(type) {
 	case webhook.NotificationRequestItem:

--- a/src/hmacvalidator/hmacvalidator_test.go
+++ b/src/hmacvalidator/hmacvalidator_test.go
@@ -29,6 +29,27 @@ var notificationRequestItem = webhook.NotificationRequestItem{
 	Success:             "true",
 }
 
+// webhook payload as string
+const payloadAsString = `{
+    "type": "merchant.created",
+    "environment": "test",
+    "createdAt": "01-01-2024",
+    "data": {
+        "capabilities": {
+            "sendToTransferInstrument": {
+                "requested": true,
+                "requestedLevel": "notApplicable"
+            }
+        },
+        "companyId": "YOUR_COMPANY_ID",
+        "merchantId": YOUR_MERCHANT_ACCOUNT",
+        "status": "PreActive"
+    }
+}`
+
+// signature for the webhook payload above
+const expectedSignFromPayloadAsString = "yitBTPnDGtbAMG9rTxUa1e6lFGpa4PnrD6rErOmEhJ8="
+
 func Test_Hmacvalidator(t *testing.T) {
 	t.Run("GetDataToSign", func(t *testing.T) {
 		t.Run("Get correct data", func(t *testing.T) {
@@ -66,6 +87,14 @@ func Test_Hmacvalidator(t *testing.T) {
 		t.Run("Get Invalid HMAC", func(t *testing.T) {
 			notificationRequestItem.AdditionalData = &map[string]interface{}{"hmacSignature": "InvalidSignature"}
 			assert.False(t, ValidateHmac(notificationRequestItem, key))
+		})
+	})
+	t.Run("ValidateHmacPayload", func(t *testing.T) {
+		t.Run("Validate HMAC from string payload", func(t *testing.T) {
+			assert.True(t, ValidateHmacPayload(expectedSignFromPayloadAsString, key, payloadAsString))
+		})
+		t.Run("Test invalid HMAC from string payload", func(t *testing.T) {
+			assert.False(t, ValidateHmacPayload("invalidSignature=", key, payloadAsString))
 		})
 	})
 }

--- a/src/hmacvalidator/hmacvalidator_test.go
+++ b/src/hmacvalidator/hmacvalidator_test.go
@@ -94,7 +94,7 @@ func Test_Hmacvalidator(t *testing.T) {
 			assert.True(t, ValidateHmacPayload(expectedSignFromPayloadAsString, key, payloadAsString))
 		})
 		t.Run("Test invalid HMAC from string payload", func(t *testing.T) {
-			assert.False(t, ValidateHmacPayload("invalidSignature=", key, payloadAsString))
+			assert.False(t, ValidateHmacPayload("MismatchingHmacKey=", key, payloadAsString))
 		})
 	})
 }


### PR DESCRIPTION
## Summary
The library provides only support for validating webhook payloads that include the HMAC signature in the request body `AdditionalData` (i.e. standard webhooks).  
This PR adds a method to validate the webhook payloads that include the HMAC signature in the HTTP header (.i.e banking webhooks).

## Tested scenarios
Added unit testing, tested with with [Adyen Sample app](https://github.com/adyen-examples/adyen-golang-online-payments)
