### PR TITLE
adjust template and remove unnecessary type for default

### DIFF
--- a/templates/custom/model_simple.mustache
+++ b/templates/custom/model_simple.mustache
@@ -48,7 +48,7 @@ func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}
 {{^vendorExtensions.x-golang-is-container}}
 {{^isReadOnly}}
 {{#isNullable}}
-	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	var {{nameInCamelCase}} = {{{.}}}
 	this.{{name}} = *common.New{{{dataType}}}(&{{nameInCamelCase}})
 {{/isNullable}}
 {{^isNullable}}
@@ -74,7 +74,7 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{^isReadOnly}}
 {{#isNullable}}
 {{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
-	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	var {{nameInCamelCase}} = {{{.}}}
 	this.{{name}} = *common.New{{{dataType}}}(&{{nameInCamelCase}})
 {{/isNullable}}
 {{^isNullable}}


### PR DESCRIPTION
OAS type nullable string with default breaks a certain mustache type. We don't need this type as go handles var assignment without type fine. 