### PR TITLE
fix stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,15 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been automatically marked as stale due to inactivity and will be closed in 7 days if no further activity occurs.'
           close-issue-message: 'This issue was closed due to inactivity. Please reopen if you still encounter this problem or have more information to add.'
-          days-before-stale: 14
-          days-before-close: 7
+          stale-pr-message: "This PR hasn't received any updates in a year and will be automatically closed in 30 days. Feel free to re-open if you plan to continue working on this pull request"
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
           stale-issue-label: 'stale'
           exempt-issue-labels: 'do not stale, needs response'
+          days-before-pr-stale: 365
+          days-before-pr-close: 30
+          exempt-pr-labels: 'do not stale'
+          only-pr-labels: awaiting-changes,blocked,work-in-progress,awaiting-upstream
+          remove-pr-stale-when-updated: true


### PR DESCRIPTION
updated stale.yml to ignore pull requests.
unset the default checks by setting them to -1 only consider pr's with the labels 'awaiting-changes', 'blocked', 'work-in-progress', 'awaiting-upstream'. removing the pr label when updated
