### PR TITLE
removed issuer string from NewIdealDetails

### DIFF
--- a/tests/checkout/integration_test.go
+++ b/tests/checkout/integration_test.go
@@ -94,7 +94,7 @@ func TestCheckoutIntegration(t *testing.T) {
 		t.Run("iDEAL payment", func(t *testing.T) {
 			idempotencyKey := uuid.New().String()
 			ctx := common.WithIdempotencyKey(context.Background(), idempotencyKey)
-			ideal := checkout.NewIdealDetails("1121")
+			ideal := checkout.NewIdealDetails()
 			paymentRequest := *checkout.NewPaymentRequest(
 				*checkout.NewAmount("EUR", int64(1234)),
 				merchantAccount,


### PR DESCRIPTION
checkout/integration test was failing because Issuer is no longer required and setter is removed.

[src/checkout/model_ideal_details.go](https://github.com/Adyen/adyen-go-api-library/pull/342/files#diff-ba35d55e88aad387be5735dde8ab4a8099294170d6c9dc42227ae618cb656a23)
[src/checkout/model_ideal_donations.go](https://github.com/Adyen/adyen-go-api-library/pull/342/files#diff-cfdd899069fbd01041b4b1973f412065823db1bc3a04b0c4dfcb9c9f32fedb82)

adjusted the test and want to merge into sdk-automation to see if this will solve the issue
