### PR TITLE
Pin go formatter version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 
 # Download the import optimizer (and code formatter)
 $(goimports):
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.24.0
 
 fmt: $(goimports)
 	$(goimports) -w src


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

In the formatter workflow we use [Go 1.8](https://github.com/Adyen/adyen-go-api-library/blob/453baa5b0211aaa151c4b3a561c103cbd7a39420/.github/workflows/format.yml#L20) which is not compatible with the latest version (v0.25.0, Published: Sep 9, 2024) of [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=versions). 

This change will pin the formatter to the previous version in favor of stability.