### PR TITLE
Add minimum required release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "minimumReleaseAge": "21 days",
+  "minimumReleaseAge": "21 days"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:base"
-    ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "minimumReleaseAge": "21 days",
 }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

This PR adds `"minimumReleaseAge": "21 days"` which specifies that Renovate should only consider updates for dependencies that have been released for at least **21** days.
