### PR TITLE
Remove Issuer from iDEAL Test for iDEAL2 Compatibility

### DIFF
--- a/tests/checkout/integration_test.go
+++ b/tests/checkout/integration_test.go
@@ -95,7 +95,6 @@ func TestCheckoutIntegration(t *testing.T) {
 			idempotencyKey := uuid.New().String()
 			ctx := common.WithIdempotencyKey(context.Background(), idempotencyKey)
 			ideal := checkout.NewIdealDetails()
-			ideal.SetIssuer("1121")
 			paymentRequest := *checkout.NewPaymentRequest(
 				*checkout.NewAmount("EUR", int64(1234)),
 				merchantAccount,


### PR DESCRIPTION
iDEAL2 no longer requires the issuer parameter. This PR removes the hardcoded issuer from the test to implement the iDEAL2 flow.