### PR TITLE
Add close-issue-label flag to correctly label closed issues 

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
           days-before-issue-stale: 14
           days-before-issue-close: 7
           stale-issue-label: 'stale'
+          close-issue-label: 'closed-due-to-inactivity'
           exempt-issue-labels: 'do not stale, needs response'
           days-before-pr-stale: 365
           days-before-pr-close: 30


### PR DESCRIPTION
This PR updates the stale issue workflow by adding the close-issue-label flag. Previously, when issues were closed due to inactivity, they were automatically marked as "closed as not planned", which was misleading. Now, a custom label is applied when an issue is closed due to inactivity.

Testing:
* Forked the repository to test the changes.
* Modified the workflow to run more frequently and reduced stale/close time.

Verified that:
* Issues were correctly marked as stale.
* Issues were closed with the new label "closed-due-to-inactivity" instead of the default label.