### PR TITLE
Add nil-check for AdditionalData in ValidateHmac

### DIFF
--- a/src/hmacvalidator/hmacvalidator.go
+++ b/src/hmacvalidator/hmacvalidator.go
@@ -32,6 +32,11 @@ func CalculateHmac(data interface{}, secret string) (string, error) {
 // notificationRequestItem: NotificationRequestItem object
 // key: HMAC key to generate the signature
 func ValidateHmac(notificationRequestItem webhook.NotificationRequestItem, key string) bool {
+	// Check for nil AdditionalData first to prevent code panic.
+	if notificationRequestItem.AdditionalData == nil {
+		return false
+	}
+
 	expectedSign, err := CalculateHmac(notificationRequestItem, key)
 	if err != nil {
 		return false

--- a/src/hmacvalidator/hmacvalidator_test.go
+++ b/src/hmacvalidator/hmacvalidator_test.go
@@ -88,6 +88,12 @@ func Test_Hmacvalidator(t *testing.T) {
 			notificationRequestItem.AdditionalData = &map[string]interface{}{"hmacSignature": "InvalidSignature"}
 			assert.False(t, ValidateHmac(notificationRequestItem, key))
 		})
+		t.Run("Nil AdditionalData", func(t *testing.T) {
+            // Create a copy and set AdditionalData to nil.
+            testItem := notificationRequestItem
+            testItem.AdditionalData = nil
+            assert.False(t, ValidateHmac(testItem, key))
+        })
 	})
 	t.Run("ValidateHmacPayload", func(t *testing.T) {
 		t.Run("Validate HMAC from string payload", func(t *testing.T) {


### PR DESCRIPTION

This pull request adds a check to ensure that AdditionalData is not nil before it is used. This prevents a panic when AdditionalData is nil in the ValidateHmac function. If AdditionalData is nil, the function now returns false.