### PR TITLE
feat(ci): run formatter before creating commits

### DIFF
--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -1,0 +1,18 @@
+name: 'Format Go Code'
+description: 'Runs make fmt'
+inputs:
+  path:
+    description: 'Path to the go repository'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5
+      with:
+          go-version: 1.23
+
+    - name: Format Code
+      run: make fmt
+      shell: bash
+      working-directory: ${{ inputs.path }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,42 +1,37 @@
-name: Go Format
+name: Format and Commit Go Code
 
 on:
-    push:
-        branches:
-            - 'sdk-automation/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
-    format:
-        if: ${{ github.event.commits != null && !startsWith(github.event.head_commit.message, 'style(fmt)') }}
-        permissions:
-            contents: write
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-              with:
-                  token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+          ref: ${{ github.ref }}
 
-            - name: Log Commit Details
-              run: |
-                  echo "github.event.size: ${{ github.event.size }}"
-                  echo "github.event.commits: ${{ github.event.commits }}"
+      - name: Format Go Code
+        uses: ./.github/actions/format
+        with:
+          path: .
 
-            - name: Setup Go
-              uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5
-              with:
-                  go-version: 1.23
+      - name: Configure Git
+        run: |
+            git config user.name AdyenAutomationBot
+            git config user.email "${{ secrets.ADYEN_AUTOMATION_BOT_EMAIL }}"
 
-            - name: Format Code
-              run: make fmt
-
-            - name: Configure Git
-              run: |
-                  git config user.name AdyenAutomationBot
-                  git config user.email "${{ secrets.ADYEN_AUTOMATION_BOT_EMAIL }}"
-
-            - name: Commit and Push Changes
-              run: |
-                  git add .
-                  git commit -m "style(fmt): code formatted"
-                  git push
+      - name: Commit and Push Changes
+        run: |
+            git add .
+            if git diff --staged --quiet; then
+              echo "No changes to commit"
+            else
+              git commit -m "style(fmt): code formatted"
+              git push
+            fi


### PR DESCRIPTION
Moves the formatting step to happen before commits are made in the sdk-automation-repo.

This change introduces a reusable GitHub Action for formatting the Go code. The existing formatting workflow is updated to be manually triggerable and to use this new action.

This aligns the Go library with the process used by other Adyen libraries, where formatting is part of the code generation workflow.