### PR TITLE
fix: use hmac.Equals for signature comparison

### DIFF
--- a/src/hmacvalidator/hmacvalidator.go
+++ b/src/hmacvalidator/hmacvalidator.go
@@ -41,8 +41,11 @@ func ValidateHmac(notificationRequestItem webhook.NotificationRequestItem, key s
 	if err != nil {
 		return false
 	}
-	merchantSign := (*notificationRequestItem.AdditionalData)["hmacSignature"]
-	return expectedSign == merchantSign
+	merchantSign, present := (*notificationRequestItem.AdditionalData)["hmacSignature"]
+	if !present {
+		return false
+	}
+	return hmac.Equal([]byte(expectedSign), []byte(merchantSign))
 }
 
 // ValidateHmacPayload validates the HMAC signature of a payload against an expected signature. Use for webhooks that provide the
@@ -57,7 +60,7 @@ func ValidateHmacPayload(hmacSignature string, key string, payload string) bool 
 	if err != nil {
 		return false
 	}
-	return expectedSign == hmacSignature
+	return hmac.Equal([]byte(expectedSign), []byte(hmacSignature))
 }
 
 // GetDataToSign converts a notificationRequestItem to string, which later on can be used for calculating a HMAC

--- a/src/hmacvalidator/hmacvalidator_test.go
+++ b/src/hmacvalidator/hmacvalidator_test.go
@@ -13,7 +13,7 @@ const expectedSign = "ipnxGCaUZ4l8TUW75a71/ghd2Fe5ffvX0pV4TLTntIc="
 
 var eventDate = time.Date(1970, time.January, 01, 0, 0, 0, 0, time.UTC)
 var notificationRequestItem = webhook.NotificationRequestItem{
-	AdditionalData: &map[string]interface{}{"hmacSignature": expectedSign},
+	AdditionalData: &map[string]string{"hmacSignature": expectedSign},
 	Amount: webhook.Amount{
 		Currency: "EUR",
 		Value:    1000,
@@ -85,7 +85,7 @@ func Test_Hmacvalidator(t *testing.T) {
 			assert.True(t, ValidateHmac(notificationRequestItem, key))
 		})
 		t.Run("Get Invalid HMAC", func(t *testing.T) {
-			notificationRequestItem.AdditionalData = &map[string]interface{}{"hmacSignature": "InvalidSignature"}
+			notificationRequestItem.AdditionalData = &map[string]string{"hmacSignature": "InvalidSignature"}
 			assert.False(t, ValidateHmac(notificationRequestItem, key))
 		})
 		t.Run("Nil AdditionalData", func(t *testing.T) {

--- a/src/webhook/model_notification_request_item.go
+++ b/src/webhook/model_notification_request_item.go
@@ -3,16 +3,16 @@ package webhook
 import "time"
 
 type NotificationRequestItem struct {
-	AdditionalData      *map[string]interface{} `json:"additionalData,omitempty"`
-	Amount              Amount                  `json:"amount"`
-	EventCode           string                  `json:"eventCode"`
-	EventDate           *time.Time              `json:"eventDate"`
-	MerchantAccountCode string                  `json:"merchantAccountCode"`
-	MerchantReference   string                  `json:"merchantReference"`
-	Operations          []string                `json:"operations,omitempty"`
-	OriginalReference   string                  `json:"originalReference,omitempty"`
-	PaymentMethod       string                  `json:"paymentMethod"`
-	PspReference        string                  `json:"pspReference"`
-	Reason              string                  `json:"reason"`
-	Success             string                  `json:"success"`
+	AdditionalData      *map[string]string `json:"additionalData,omitempty"`
+	Amount              Amount             `json:"amount"`
+	EventCode           string             `json:"eventCode"`
+	EventDate           *time.Time         `json:"eventDate"`
+	MerchantAccountCode string             `json:"merchantAccountCode"`
+	MerchantReference   string             `json:"merchantReference"`
+	Operations          []string           `json:"operations,omitempty"`
+	OriginalReference   string             `json:"originalReference,omitempty"`
+	PaymentMethod       string             `json:"paymentMethod"`
+	PspReference        string             `json:"pspReference"`
+	Reason              string             `json:"reason"`
+	Success             string             `json:"success"`
 }


### PR DESCRIPTION
Hmac validation shouldn't be using plain string equals. This change also aligns Hmac signature verification across other Adyen libraries. It was also required to adjust the typing for `AdditionalData` field (for some reason it was using `interface{}` instead of `string`). For context (using Java), this was like having a `Map<String, Object>` instead of `Map<String, String>` which doesn't make sense for webhooks.
