### PR TITLE
test(checkout): align api error code from Orders API

### DIFF
--- a/tests/checkout/integration_test.go
+++ b/tests/checkout/integration_test.go
@@ -251,7 +251,7 @@ func TestCheckoutIntegration(t *testing.T) {
 			assert.Equal(t, float64(422), apiError.Status)
 			assert.Equal(t, apiError.Message, "Required field 'reference' is not provided.")
 			assert.Equal(t, "validation", apiError.Type)
-			assert.Equal(t, "130", apiError.Code)
+			assert.Equal(t, "158", apiError.Code)
 		})
 	})
 


### PR DESCRIPTION
This test was previously asserting against 130 (reference missing), while the backend returns 158 (required field * not provided):
- https://docs.adyen.com/development-resources/error-codes#158-required-field-0-not-provided
- https://docs.adyen.com/development-resources/error-codes#130-reference-missing This should unblock the release PR.