### PR TITLE
fix(templates): resolve undefined newStrictDecoder in oneOf models

### DIFF
--- a/src/common/utils.go
+++ b/src/common/utils.go
@@ -1,10 +1,20 @@
 package common
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 	"time"
 )
+
+// NewStrictDecoder returns a JSON decoder that fails on fields which are not
+// present in the target type. Generated oneOf models use it to tell candidate
+// variants apart.
+func NewStrictDecoder(data []byte) *json.Decoder {
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.DisallowUnknownFields()
+	return dec
+}
 
 // PtrBool is a helper routine that returns a pointer to given boolean value.
 func PtrBool(v bool) *bool { return &v }

--- a/templates/custom/model_oneof.mustache
+++ b/templates/custom/model_oneof.mustache
@@ -31,7 +31,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{#-first}}
 	// use discriminator value to speed up the lookup
 	var jsonDict map[string]interface{}
-	err = newStrictDecoder(data).Decode(&jsonDict)
+	err = common.NewStrictDecoder(data).Decode(&jsonDict)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal JSON into map for the discriminator lookup")
 	}
@@ -87,7 +87,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	match := 0
 	{{#oneOf}}
 	// try to unmarshal data into {{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}
-	err = newStrictDecoder(data).Decode(&dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
+	err = common.NewStrictDecoder(data).Decode(&dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
 	if err == nil {
 		json{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}, _ := json.Marshal(dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
 		if string(json{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}) == "{}" { // empty struct

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/adyen/adyen-go-api-library/v21/src/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStrictDecoder(t *testing.T) {
+	type variant struct {
+		Type string `json:"type"`
+	}
+
+	t.Run("decodes a payload with known fields only", func(t *testing.T) {
+		var got variant
+		err := common.NewStrictDecoder([]byte(`{"type":"scheme"}`)).Decode(&got)
+
+		require.NoError(t, err)
+		assert.Equal(t, "scheme", got.Type)
+	})
+
+	t.Run("rejects a payload with unknown fields", func(t *testing.T) {
+		var got variant
+		err := common.NewStrictDecoder([]byte(`{"type":"scheme","brand":"visa"}`)).Decode(&got)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field")
+	})
+
+	t.Run("accepts any key when decoding into a map", func(t *testing.T) {
+		var got map[string]interface{}
+		err := common.NewStrictDecoder([]byte(`{"type":"scheme","brand":"visa"}`)).Decode(&got)
+
+		require.NoError(t, err)
+		assert.Equal(t, "scheme", got["type"])
+	})
+}


### PR DESCRIPTION
## Summary

Both call sites in templates/custom/model_oneof.mustache referenced newStrictDecoder, a helper that upstream OpenAPI Generator defines in utils.mustache[1]. We do not use that template, so the function is defined nowhere in this repository. Several PRs related to webhooks are broken due to the oneOf discriminator that emits model that fails to compile with "undefined: newStrictDecoder".

The changes add the helper as an exported common.NewStrictDecoder and point the template at it. src/common is where generated code already looks for shared helpers (common.IsNil, common.PtrString, common.MappedNullable), and model.mustache already imports the package into every model file. A file-local definition is not an option, since packages such as checkout contain several oneOf models and the function would be redeclared.

## Tested scenarios

* Covered by a unit test for the known-field, unknown-field, and map-target cases; the map case mirrors the discriminator lookup, where strict decoding is a no-op.
* Regenerated code locally

**Fixed issue**:  <!-- #-prefixed issue number -->

This PR unblocks the following PRs:

* https://github.com/Adyen/adyen-go-api-library/pull/566
* https://github.com/Adyen/adyen-go-api-library/pull/560
* https://github.com/Adyen/adyen-go-api-library/pull/558
* https://github.com/Adyen/adyen-go-api-library/pull/548
* https://github.com/Adyen/adyen-go-api-library/pull/521


Ref:
[1] https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/go/utils.mustache



