### PR TITLE
fix(webhook): revert AdditionalData type change from hmac fix

### DIFF
--- a/src/hmacvalidator/hmacvalidator.go
+++ b/src/hmacvalidator/hmacvalidator.go
@@ -41,8 +41,12 @@ func ValidateHmac(notificationRequestItem webhook.NotificationRequestItem, key s
 	if err != nil {
 		return false
 	}
-	merchantSign, present := (*notificationRequestItem.AdditionalData)["hmacSignature"]
+	raw, present := (*notificationRequestItem.AdditionalData)["hmacSignature"]
 	if !present {
+		return false
+	}
+	merchantSign, ok := raw.(string)
+	if !ok {
 		return false
 	}
 	return hmac.Equal([]byte(expectedSign), []byte(merchantSign))

--- a/src/hmacvalidator/hmacvalidator_test.go
+++ b/src/hmacvalidator/hmacvalidator_test.go
@@ -13,7 +13,7 @@ const expectedSign = "ipnxGCaUZ4l8TUW75a71/ghd2Fe5ffvX0pV4TLTntIc="
 
 var eventDate = time.Date(1970, time.January, 01, 0, 0, 0, 0, time.UTC)
 var notificationRequestItem = webhook.NotificationRequestItem{
-	AdditionalData: &map[string]string{"hmacSignature": expectedSign},
+	AdditionalData: &map[string]interface{}{"hmacSignature": expectedSign},
 	Amount: webhook.Amount{
 		Currency: "EUR",
 		Value:    1000,
@@ -85,13 +85,23 @@ func Test_Hmacvalidator(t *testing.T) {
 			assert.True(t, ValidateHmac(notificationRequestItem, key))
 		})
 		t.Run("Get Invalid HMAC", func(t *testing.T) {
-			notificationRequestItem.AdditionalData = &map[string]string{"hmacSignature": "InvalidSignature"}
+			notificationRequestItem.AdditionalData = &map[string]interface{}{"hmacSignature": "InvalidSignature"}
 			assert.False(t, ValidateHmac(notificationRequestItem, key))
 		})
 		t.Run("Nil AdditionalData", func(t *testing.T) {
 			// Create a copy and set AdditionalData to nil.
 			testItem := notificationRequestItem
 			testItem.AdditionalData = nil
+			assert.False(t, ValidateHmac(testItem, key))
+		})
+		t.Run("Missing hmacSignature key", func(t *testing.T) {
+			testItem := notificationRequestItem
+			testItem.AdditionalData = &map[string]interface{}{"someOtherKey": "someValue"}
+			assert.False(t, ValidateHmac(testItem, key))
+		})
+		t.Run("Non-string hmacSignature", func(t *testing.T) {
+			testItem := notificationRequestItem
+			testItem.AdditionalData = &map[string]interface{}{"hmacSignature": 12345}
 			assert.False(t, ValidateHmac(testItem, key))
 		})
 	})

--- a/src/webhook/model_notification_request_item.go
+++ b/src/webhook/model_notification_request_item.go
@@ -3,16 +3,16 @@ package webhook
 import "time"
 
 type NotificationRequestItem struct {
-	AdditionalData      *map[string]string `json:"additionalData,omitempty"`
-	Amount              Amount             `json:"amount"`
-	EventCode           string             `json:"eventCode"`
-	EventDate           *time.Time         `json:"eventDate"`
-	MerchantAccountCode string             `json:"merchantAccountCode"`
-	MerchantReference   string             `json:"merchantReference"`
-	Operations          []string           `json:"operations,omitempty"`
-	OriginalReference   string             `json:"originalReference,omitempty"`
-	PaymentMethod       string             `json:"paymentMethod"`
-	PspReference        string             `json:"pspReference"`
-	Reason              string             `json:"reason"`
-	Success             string             `json:"success"`
+	AdditionalData      *map[string]interface{} `json:"additionalData,omitempty"`
+	Amount              Amount                  `json:"amount"`
+	EventCode           string                  `json:"eventCode"`
+	EventDate           *time.Time              `json:"eventDate"`
+	MerchantAccountCode string                  `json:"merchantAccountCode"`
+	MerchantReference   string                  `json:"merchantReference"`
+	Operations          []string                `json:"operations,omitempty"`
+	OriginalReference   string                  `json:"originalReference,omitempty"`
+	PaymentMethod       string                  `json:"paymentMethod"`
+	PspReference        string                  `json:"pspReference"`
+	Reason              string                  `json:"reason"`
+	Success             string                  `json:"success"`
 }


### PR DESCRIPTION
Commit 51c7d968 retyped webhook.NotificationRequestItem.AdditionalData from *map[string]interface{} to *map[string]string. That was an implementation shortcut so hmac.Equal would have a string in hand, not a requirement of the fix, and it breaks compilation for any caller that type-asserts values out of that map. Under Go module semver a source-breaking change to an exported type forces v22.0.0 and the module-path rename in RELEASE_PROCESS.md, which would gate a security fix behind a manual import rewrite in every downstream project.

This restores the original type and extracts the signature with a type assertion instead. The security properties are unchanged: both comparison paths still use hmac.Equal, a missing hmacSignature key is still rejected, and a non-string value under that key is now rejected as well instead of being compared against an empty string.

The revert also removes an unflagged regression. Under *map[string]string, a notification whose additionalData carries any non-string JSON value would fail to unmarshal in full, and no fixture in the repository covers that case. src/webhook is hand-written rather than generated, so the restored type will not be overwritten by the next generator run.

Covered by two new ValidateHmac subtests for the missing-key and non-string cases, both operating on copies of the shared fixture since the existing invalid-signature subtest mutates it in place.
