### PR TITLE
chore(release): retract v21.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/adyen/adyen-go-api-library/v21
 
 go 1.23.0
 
+retract v21.2.1 // Source-breaking change to webhook.NotificationRequestItem.AdditionalData. Use v21.2.2 or later.
+
+// Maintainers: keep the retract directive above in every subsequent release.
+// The go command reads retractions only from the go.mod of the highest
+// published version, so dropping it would make v21.2.1 selectable again.
+
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
v21.2.1 was merged and tagged before the webhook backwards-compatibility fix landed, so it ships a source-breaking change to webhook.NotificationRequestItem.AdditionalData, retyped from *map[string]interface{} to *map[string]string, inside what is otherwise a patch release. Any caller that type-asserts values out of that map stops compiling after an unattended go get -u.

Deleting the GitHub release does not unpublish the version. proxy.golang.org caches module versions immutably and still serves v21.2.1 pinned to 4a50982c, currently as @latest. The tag must therefore stay exactly where it is: removing or repointing it would not withdraw the version, and would instead produce checksum mismatch errors against sum.golang.org for everyone who already fetched it. Retraction is the only supported way to take a published version out of circulation.

This records the retraction only. The code fix is a separate change on the fix-webhook-backwards-compatibility branch, and both need to land before v21.2.2 is tagged, since the go command reads retractions from the go.mod of the highest published version.

