### PR TITLE
Add SDK labeler workflow

### DIFF
--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -1,0 +1,24 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: label-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: Adyen/adyen-sdk-pr-labeler-action@feat/separate-labels
+        with:
+          language: go
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the SDK PR labeler workflow using Adyen/adyen-sdk-pr-labeler-action@feat/separate-labels. Replaces the fork-based PR #592, since fork PRs cannot resolve actions from private org repositories.