### PR TITLE
fix(ci): harden GitHub Actions permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
                   go-version: ${{ matrix.go-version }}
 
             - name: Clean module cache directory
-              run: sudo rm -rf ~/go/pkg/mod
+              run: rm -rf ~/go/pkg/mod
 
             - name: Cache Go modules
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -74,7 +74,7 @@ jobs:
                   go-version: ${{ matrix.go-version }}
 
             - name: Clean module cache directory
-              run: sudo rm -rf ~/go/pkg/mod
+              run: rm -rf ~/go/pkg/mod
 
             - name: Cache Go modules
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/label_new_issues.yml
+++ b/.github/workflows/label_new_issues.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   add-label:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Add 'needs response' label to new issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10


### PR DESCRIPTION
Hardens GitHub Actions workflows by removing unnecessary elevated privileges and defining minimum token permissions.
