### PR TITLE
fix(ci): use job-local Go module cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,15 +29,15 @@ jobs:
               with:
                   go-version: ${{ matrix.go-version }}
 
-            - name: Clean module cache directory
-              run: rm -rf ~/go/pkg/mod
+            - name: Configure module cache
+              run: echo "GOMODCACHE=$RUNNER_TEMP/go/pkg/mod" >> "$GITHUB_ENV"
 
             - name: Cache Go modules
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
               with:
                   path: |
                       ~/.cache/go-build
-                      ~/go/pkg/mod
+                      ${{ runner.temp }}/go/pkg/mod
                   key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                   restore-keys: |
                       ${{ runner.os }}-go-
@@ -73,15 +73,15 @@ jobs:
               with:
                   go-version: ${{ matrix.go-version }}
 
-            - name: Clean module cache directory
-              run: rm -rf ~/go/pkg/mod
+            - name: Configure module cache
+              run: echo "GOMODCACHE=$RUNNER_TEMP/go/pkg/mod" >> "$GITHUB_ENV"
 
             - name: Cache Go modules
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
               with:
                   path: |
                       ~/.cache/go-build
-                      ~/go/pkg/mod
+                      ${{ runner.temp }}/go/pkg/mod
                   key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                   restore-keys: |
                       ${{ runner.os }}-go-


### PR DESCRIPTION
## Description

Use a job-local Go module cache to avoid permission failures while cleaning the runner-shared module cache. No privileged commands or workflow permission changes are introduced.

## Tested scenarios

- Parsed `.github/workflows/go.yml` with Ruby YAML.
- Ran `git diff --check`.
- Verified the Go matrix, cache keys, action pins, dependency download, build, and test commands remain unchanged.
- `actionlint` was unavailable locally.

## Fixed issue

N/A
